### PR TITLE
HH-150164 Upstreams creation from dict on HttpClient init fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,14 @@ setup(
         'tornado >= 5.1',
         'pycurl >= 7.43.0',
         'lxml >= 3.5.0',
+        'dataclasses >= 0.8',
     ],
     test_suite='tests',
     tests_require=[
         'pytest <= 3.8.2',
         'pycodestyle == 2.5.0',
         'tornado >= 5.1',
+        'dataclasses >= 0.8',
     ],
     zip_safe=False
 )


### PR DESCRIPTION
@Aulust привет! На одном [проекте](https://github.com/hhru/vr_platform) возникла необходимость заюзать клиента, и у меня возникли определенные трудности с этим, @Iskuskov сказал обратиться к тебе)

Когда пытаюсь заинитить клиента по примеру из ридми получаю   

```
File "/usr/local/lib/python3.6/site-packages/balancing_http_client-1.1.12-py3.6.egg/http_client/__init__.py", line 311, in __init__
    self.connect_timeout = self.upstream.connect_timeout
AttributeError: 'dict' object has no attribute 'connect_timeout'
```

Поэтому предлагаю свой патч, который парсит апстримы при создании клиента, и если это словари то делает из них инстансы Upstream. Или мб нужно совершенно иначе как-то пользоваться вообще клиентом?)

Еще добавил в зависимости dataclasses, чтоб не доставлять специально отдельно)

p.s. форкнулся потому что нет доступа к родному репозиторию